### PR TITLE
[MM-15374] Getting basic meetings working

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/hashicorp/go-hclog v0.9.2 // indirect
 	github.com/hashicorp/go-plugin v1.0.1 // indirect
 	github.com/lib/pq v1.1.1 // indirect
-	github.com/mattermost/mattermost-plugin-zoom v1.0.7
 	github.com/mattermost/mattermost-server v5.12.0+incompatible
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/objx v0.2.0 // indirect

--- a/plugin.json
+++ b/plugin.json
@@ -17,10 +17,10 @@
     "settings_schema": {
         "settings": [
             {
-                "key": "SiteURL",
-                "display_name": "Webex Site URL",
+                "key": "SiteHost",
+                "display_name": "Webex Site Hostname",
                 "type": "text",
-                "help_text": "The URL for your team's Webex site. For example: teamsite.webex.com",
+                "help_text": "The hostname for your team's Webex site. For example: teamsite.webex.com",
                 "placeholder": "teamsite.webex.com"
             }
         ]

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "id": "com.mattermost.webex",
     "name": "Webex",
-    "description": "Webex audio and video conferencing plugin for Mattermost 5.12+.",
+    "description": "Webex audio and video conferencing plugin for Mattermost.",
     "version": "0.0.1",
     "min_server_version": "5.12.0",
     "server": {

--- a/server/command.go
+++ b/server/command.go
@@ -19,7 +19,7 @@ type CommandHandler struct {
 	defaultHandler CommandHandlerFunc
 }
 
-var jiraCommandHandler = CommandHandler{
+var webexCommandHandler = CommandHandler{
 	handlers: map[string]CommandHandlerFunc{
 		"help": commandHelp,
 		"info": executeInfo,
@@ -56,7 +56,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, commandArgs *model.CommandArg
 	if len(args) == 0 || args[0] != "/webex" {
 		return p.help(commandArgs), nil
 	}
-	return jiraCommandHandler.Handle(p, c, commandArgs, args[1:]...), nil
+	return webexCommandHandler.Handle(p, c, commandArgs, args[1:]...), nil
 }
 
 func getCommand() *model.Command {

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"regexp"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -109,5 +110,5 @@ func parseHostFromUrl(url string) string {
 	if matches != nil {
 		return matches[1]
 	}
-	return url
+	return strings.TrimSpace(url)
 }

--- a/server/http.go
+++ b/server/http.go
@@ -4,14 +4,19 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
+	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin"
 	"net/http"
+	"net/url"
 	"strconv"
 )
 
 const (
 	routeAPImeetings = "/api/v1/meetings"
+	StatusStarted    = "STARTED"
 )
 
 func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
@@ -37,180 +42,86 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 
 func handleHTTPRequest(p *Plugin, w http.ResponseWriter, r *http.Request) (int, error) {
 	switch r.URL.Path {
-	//case routeWebhook:
-	//	return p.handleWebhook(w, r)
-	//case routeAPImeetings:
-	//	return p.handleStartMeeting(w, r)
+	case routeAPImeetings:
+		return p.handleStartMeeting(w, r)
 	}
 
 	return http.StatusNotFound, errors.New("not found")
 }
 
-//func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
-//	//config := p.getConfiguration()
-//	//secret := config.WebhookSecret
-//	secret := ""
-//	if subtle.ConstantTimeCompare([]byte(r.URL.Query().Get("secret")), []byte(secret)) != 1 {
-//		http.Error(w, "Not authorized", http.StatusUnauthorized)
-//		return
-//	}
-//
-//	if err := r.ParseForm(); err != nil {
-//		http.Error(w, "Bad request body", http.StatusBadRequest)
-//		return
-//	}
-//
-//	var webhook webex.Webhook
-//	decoder := schema.NewDecoder()
-//
-//	// Try to decode to standard webhook
-//	if err := decoder.Decode(&webhook, r.PostForm); err != nil {
-//		http.Error(w, err.Error(), http.StatusBadRequest)
-//		return
-//	}
-//
-//	p.handleStandardWebhook(w, r, &webhook)
-//
-//	// TODO: handle recording webhook
-//}
-//
-//func (p *Plugin) handleStandardWebhook(w http.ResponseWriter, r *http.Request, webhook *webex.Webhook) {
-//	if webhook.Status != webex.WebhookStatusStarted {
-//		return
-//	}
-//
-//	key := fmt.Sprintf("%v%v", postMeetingKey, webhook.ID)
-//	b, appErr := p.API.KVGet(key)
-//	if appErr != nil {
-//		http.Error(w, appErr.Error(), appErr.StatusCode)
-//		return
-//	}
-//
-//	if b == nil {
-//		return
-//	}
-//	postID := string(b)
-//
-//	post, appErr := p.API.GetPost(postID)
-//	if appErr != nil {
-//		http.Error(w, appErr.Error(), appErr.StatusCode)
-//		return
-//	}
-//
-//	post.Message = "Meeting has ended."
-//	post.Props["meeting_status"] = webex.WebhookStatusEnded
-//
-//	if _, appErr := p.API.UpdatePost(post); appErr != nil {
-//		http.Error(w, appErr.Error(), appErr.StatusCode)
-//		return
-//	}
-//
-//	if appErr := p.API.KVDelete(key); appErr != nil {
-//		p.API.LogWarn("failed to delete db entry", "error", appErr.Error())
-//		return
-//	}
-//
-//	if _, err := w.Write([]byte(post.ToJson())); err != nil {
-//		p.API.LogWarn("failed to write response", "error", err.Error())
-//	}
-//}
-//
-//type startMeetingRequest struct {
-//	ChannelID string `json:"channel_id"`
-//	Personal  bool   `json:"personal"`
-//	Topic     string `json:"topic"`
-//	MeetingID int    `json:"meeting_id"`
-//}
-//
-//func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {
-//	//config := p.getConfiguration()
-//
-//	userID := r.Header.Get("Mattermost-User-Id")
-//	if userID == "" {
-//		http.Error(w, "Not authorized", http.StatusUnauthorized)
-//		return
-//	}
-//
-//	var req startMeetingRequest
-//	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-//		http.Error(w, err.Error(), http.StatusBadRequest)
-//		return
-//	}
-//
-//	user, appErr := p.API.GetUser(userID)
-//	if appErr != nil {
-//		http.Error(w, appErr.Error(), appErr.StatusCode)
-//		return
-//	}
-//
-//	if _, appErr = p.API.GetChannelMember(req.ChannelID, userID); appErr != nil {
-//		http.Error(w, "Forbidden", http.StatusForbidden)
-//		return
-//	}
-//
-//	meetingID := req.MeetingID
-//	personal := req.Personal
-//
-//	if meetingID == 0 && req.Personal {
-//		ru, clientErr := p.webexClient.GetUser(user.Email)
-//		if clientErr != nil {
-//			http.Error(w, clientErr.Error(), clientErr.StatusCode)
-//			return
-//		}
-//		meetingID = ru.Pmi
-//	}
-//
-//	if meetingID == 0 {
-//		personal = false
-//
-//		meeting := &webex.Meeting{
-//			Type:  webex.MeetingTypeInstant,
-//			Topic: req.Topic,
-//		}
-//
-//		rm, clientErr := p.webexClient.CreateMeeting(meeting, user.Email)
-//		if clientErr != nil {
-//			http.Error(w, clientErr.Error(), clientErr.StatusCode)
-//			return
-//		}
-//		meetingID = rm.ID
-//	}
-//
-//	//url := config.ZoomURL
-//	url := ""
-//	zoomURL := strings.TrimSpace(url)
-//	if len(zoomURL) == 0 {
-//		zoomURL = "https://zoom.us"
-//	}
-//
-//	meetingURL := fmt.Sprintf("%s/j/%v", zoomURL, meetingID)
-//
-//	post := &model.Post{
-//		UserId:    p.botUserID,
-//		ChannelId: req.ChannelID,
-//		Message:   fmt.Sprintf("Meeting started at %s.", meetingURL),
-//		Type:      "custom_zoom",
-//		Props: map[string]interface{}{
-//			"meeting_id":       meetingID,
-//			"meeting_link":     meetingURL,
-//			"meeting_status":   webex.WebhookStatusStarted,
-//			"meeting_personal": personal,
-//			"meeting_topic":    req.Topic,
-//		},
-//	}
-//
-//	createdPost, appErr := p.API.CreatePost(post)
-//	if appErr != nil {
-//		http.Error(w, appErr.Error(), appErr.StatusCode)
-//		return
-//	}
-//
-//	if appErr = p.API.KVSet(fmt.Sprintf("%v%v", postMeetingKey, meetingID), []byte(createdPost.Id)); appErr != nil {
-//		http.Error(w, appErr.Error(), appErr.StatusCode)
-//		return
-//	}
-//
-//	if _, err := w.Write([]byte(fmt.Sprintf("%v", meetingID))); err != nil {
-//		p.API.LogWarn("failed to write response", "error", err.Error())
-//	}
-//}
+type startMeetingRequest struct {
+	ChannelID string `json:"channel_id"`
+	MeetingID int    `json:"meeting_id"`
+}
+
+func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) (int, error) {
+	//config := p.getConfiguration()
+
+	userId := r.Header.Get("Mattermost-User-Id")
+	if userId == "" {
+		return http.StatusUnauthorized, errors.New("not authorized")
+	}
+
+	var req startMeetingRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return http.StatusBadRequest, fmt.Errorf("err: %v", err)
+	}
+
+	if _, appErr := p.API.GetChannelMember(req.ChannelID, userId); appErr != nil {
+		return http.StatusForbidden, errors.New("forbidden")
+	}
+
+	roomId, err := p.getRoomOrDefault(userId)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	siteURL := p.getConfiguration().SiteHost
+	if siteURL == "" {
+		return http.StatusInternalServerError, errors.New("Unable to setup a meeting; the Webex plugin has not been configured yet.\nPlease ask your system administrator to set the `Webex Site Hostname` in `System Console -> PLUGINS -> Webex`.")
+	}
+
+	webexJoinURL := (&url.URL{
+		Scheme: "https",
+		Host:   siteURL,
+		Path:   "/join/" + roomId,
+	}).String()
+
+	webexStartURL := (&url.URL{
+		Scheme: "https",
+		Host:   siteURL,
+		Path:   "/start/" + roomId,
+	}).String()
+
+	joinPost := &model.Post{
+		UserId:    p.botUserID,
+		ChannelId: req.ChannelID,
+		Message:   fmt.Sprintf("Meeting started at %s.", webexJoinURL),
+		Type:      "custom_webex",
+		Props: map[string]interface{}{
+			"meeting_link":     webexJoinURL,
+			"meeting_status":   StatusStarted,
+			"meeting_topic":    "Webex Meeting",
+			"starting_user_id": userId,
+		},
+	}
+
+	createdPost, appErr := p.API.CreatePost(joinPost)
+	if appErr != nil {
+		return appErr.StatusCode, appErr
+	}
+
+	startPost := &model.Post{
+		UserId:    p.botUserID,
+		ChannelId: req.ChannelID,
+		Message:   fmt.Sprintf("To start the meeting, click here: %s.", webexStartURL),
+	}
+
+	_ = p.API.SendEphemeralPost(userId, startPost)
+
+	if _, err := w.Write([]byte(fmt.Sprintf("%v", createdPost.Id))); err != nil {
+		p.API.LogWarn("failed to write response", "error", err.Error())
+	}
+
+	return http.StatusOK, nil
+}

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License for license information.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/plugin"
+	"github.com/mattermost/mattermost-server/plugin/plugintest"
+	"github.com/mattermost/mattermost-server/plugin/plugintest/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlugin(t *testing.T) {
+	noAuthMeetingRequest := httptest.NewRequest("POST", "/api/v1/meetings",
+		strings.NewReader("{\"channel_id\": \"thechannelid\"}"))
+
+	validMeetingRequest := httptest.NewRequest("POST", "/api/v1/meetings",
+		strings.NewReader("{\"channel_id\": \"thechannelid\"}"))
+	validMeetingRequest.Header.Add("Mattermost-User-Id", "theuserid")
+
+	validMeetingRequest2 := httptest.NewRequest("POST", "/api/v1/meetings",
+		strings.NewReader("{\"channel_id\": \"thechannelid\"}"))
+	validMeetingRequest2.Header.Add("Mattermost-User-Id", "theuserid")
+
+	invalidMeetingRequestGet := httptest.NewRequest("GET", "/api/v1/meetings",
+		strings.NewReader("{\"channel_id\": \"thechannelid\"}"))
+	invalidMeetingRequestGet.Header.Add("Mattermost-User-Id", "theuserid")
+
+	invalidMeetingRequestNoChannel := httptest.NewRequest("POST", "/api/v1/meetings",
+		strings.NewReader("{\"channellll_id\": \"thechannelid\"}"))
+	invalidMeetingRequestNoChannel.Header.Add("Mattermost-User-Id", "theuserid")
+
+	for _, tc := range []struct {
+		Name               string
+		Request            *http.Request
+		SiteHost           string
+		ExpectedStatusCode int
+	}{
+		{
+			Name:               "Unauthorized meeting request",
+			Request:            noAuthMeetingRequest,
+			SiteHost:           "hostname.webex.com",
+			ExpectedStatusCode: http.StatusUnauthorized,
+		},
+		{
+			Name:               "Valid meeting request",
+			Request:            validMeetingRequest,
+			SiteHost:           "hostname.webex.com",
+			ExpectedStatusCode: http.StatusOK,
+		},
+		{
+			Name:               "No SiteHost set",
+			Request:            validMeetingRequest2,
+			SiteHost:           "",
+			ExpectedStatusCode: http.StatusInternalServerError,
+		},
+		{
+			Name:               "Invalid meeting request: using Get",
+			Request:            invalidMeetingRequestGet,
+			SiteHost:           "hostname.webex.com",
+			ExpectedStatusCode: http.StatusMethodNotAllowed,
+		},
+		{
+			Name:               "Invalid meeting request: no channel",
+			Request:            invalidMeetingRequestNoChannel,
+			SiteHost:           "hostname.webex.com",
+			ExpectedStatusCode: http.StatusBadRequest,
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			botUserID := "ason34aygl13nms0823nmastj3n99n"
+
+			api := &plugintest.API{}
+
+			api.On("GetChannelMember", "thechannelid", "theuserid").Return(&model.ChannelMember{}, nil)
+
+			path, err := filepath.Abs("..")
+			require.Nil(t, err)
+			api.On("GetBundlePath").Return(path, nil)
+			api.On("SetProfileImage", botUserID, mock.Anything).Return(nil)
+			api.On("RegisterCommand", mock.Anything).Return(nil)
+			api.On("LogDebug",
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string")).Return(nil)
+			api.On("LogError",
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string"),
+				mock.AnythingOfTypeArgument("string")).Return(nil)
+
+			user, _ := json.Marshal(UserInfo{"myroom"})
+			api.On("KVGet", mock.AnythingOfTypeArgument("string")).Return(user, (*model.AppError)(nil))
+
+			api.On("CreatePost",
+				mock.AnythingOfType("*model.Post")).Return(&model.Post{}, nil)
+			api.On("SendEphemeralPost",
+				mock.AnythingOfType("string"),
+				mock.AnythingOfType("*model.Post")).Return(nil)
+
+			p := Plugin{}
+			p.setConfiguration(&configuration{
+				SiteHost: tc.SiteHost,
+			})
+			p.SetAPI(api)
+
+			p.store = mockStore{}
+
+			helpers := &plugintest.Helpers{}
+			helpers.On("EnsureBot", mock.AnythingOfType("*model.Bot")).Return(botUserID, nil)
+			p.SetHelpers(helpers)
+
+			err = p.OnActivate()
+			require.Nil(t, err)
+
+			w := httptest.NewRecorder()
+
+			p.ServeHTTP(&plugin.Context{}, w, tc.Request)
+			assert.Equal(t, tc.ExpectedStatusCode, w.Result().StatusCode)
+
+			if w.Result().StatusCode != http.StatusOK {
+				return
+			}
+
+			webexJoinURL := "https://" + tc.SiteHost + "/join/myroom"
+			expectedJoinPost := &model.Post{
+				UserId:    p.botUserID,
+				ChannelId: "thechannelid",
+				Message:   fmt.Sprintf("Meeting started at %s.", webexJoinURL),
+				Type:      "custom_webex",
+				Props: map[string]interface{}{
+					"meeting_link":     webexJoinURL,
+					"meeting_status":   StatusStarted,
+					"meeting_topic":    "Webex Meeting",
+					"starting_user_id": "theuserid",
+				},
+			}
+			api.AssertCalled(t, "CreatePost", expectedJoinPost)
+
+			webexStartURL := "https://" + tc.SiteHost + "/start/myroom"
+			expectedStartPost := &model.Post{
+				UserId:    p.botUserID,
+				ChannelId: "thechannelid",
+				Message:   fmt.Sprintf("To start the meeting, click here: %s.", webexStartURL),
+			}
+			api.AssertCalled(t, "SendEphemeralPost", "theuserid", expectedStartPost)
+		})
+	}
+}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/mattermost/mattermost-plugin-webex/server/webex"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
@@ -27,8 +26,6 @@ const (
 type Plugin struct {
 	plugin.MattermostPlugin
 
-	webexClient *webex.Client
-
 	// botUserID of the created bot account.
 	botUserID string
 
@@ -38,6 +35,9 @@ type Plugin struct {
 	// configuration is the active plugin configuration. Consult getConfiguration and
 	// setConfiguration for usage.
 	configuration *configuration
+
+	// KV store
+	store Store
 }
 
 // OnActivate checks if the configurations is valid and ensures the bot account exists
@@ -71,7 +71,7 @@ func (p *Plugin) OnActivate() error {
 		return errors.Wrap(appErr, "couldn't set profile image")
 	}
 
-	//p.webexClient = webex.NewClient(config.ClientID, config.ClientSecret)
+	p.store = NewStore(p)
 
 	err = p.API.RegisterCommand(getCommand())
 	if err != nil {

--- a/server/store.go
+++ b/server/store.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"github.com/pkg/errors"
+)
+
+const (
+	prefixUserInfo = "user_info_"
+)
+
+type Store interface {
+	StoreUserInfo(mattermostUserId string, info UserInfo) error
+	LoadUserInfo(mattermostUserId string) (UserInfo, error)
+}
+
+type store struct {
+	plugin *Plugin
+}
+
+func NewStore(p *Plugin) Store {
+	return &store{plugin: p}
+}
+
+func hashkey(prefix, key string) string {
+	h := md5.New()
+	_, _ = h.Write([]byte(key))
+	return fmt.Sprintf("%s%x", prefix, h.Sum(nil))
+}
+
+func (store store) get(key string, v interface{}) (returnErr error) {
+	defer func() {
+		if returnErr == nil {
+			return
+		}
+		returnErr = errors.WithMessage(returnErr, "failed to get from store")
+	}()
+
+	data, appErr := store.plugin.API.KVGet(key)
+	if appErr != nil {
+		return appErr
+	}
+
+	if data == nil {
+		return nil
+	}
+
+	err := json.Unmarshal(data, v)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (store store) set(key string, v interface{}) (returnErr error) {
+	defer func() {
+		if returnErr == nil {
+			return
+		}
+		returnErr = errors.WithMessage(returnErr, "failed to store")
+	}()
+
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	appErr := store.plugin.API.KVSet(key, data)
+	if appErr != nil {
+		return appErr
+	}
+	return nil
+}
+
+func (store store) StoreUserInfo(mattermostUserId string, info UserInfo) (returnErr error) {
+	err := store.set(hashkey(prefixUserInfo, mattermostUserId), info)
+	if err != nil {
+		return errors.WithMessage(err, fmt.Sprintf("failed to store UserInfo for: %s", mattermostUserId))
+
+	}
+	return nil
+}
+
+var ErrUserNotFound = errors.New("user not found")
+
+func (store store) LoadUserInfo(mattermostUserId string) (UserInfo, error) {
+	userInfo := UserInfo{}
+	err := store.get(hashkey(prefixUserInfo, mattermostUserId), &userInfo)
+	if err != nil {
+		return UserInfo{}, errors.WithMessage(err,
+			fmt.Sprintf("failed to load userInfo for mattermostUserId: %s", mattermostUserId))
+	}
+
+	if len(userInfo.RoomID) == 0 {
+		return UserInfo{}, ErrUserNotFound
+	}
+
+	return userInfo, nil
+
+}

--- a/server/store_mock_test.go
+++ b/server/store_mock_test.go
@@ -1,0 +1,10 @@
+package main
+
+type mockStore struct{}
+
+func (store mockStore) StoreUserInfo(mattermostUserId string, info UserInfo) error {
+	return nil
+}
+func (store mockStore) LoadUserInfo(mattermostUserId string) (UserInfo, error) {
+	return UserInfo{}, nil
+}

--- a/server/user.go
+++ b/server/user.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 )
 
@@ -39,7 +40,7 @@ func (p *Plugin) getRoomOrDefault(mattermostUserId string) (string, error) {
 	} else if err != nil {
 		// unexpected error
 		p.errorf("error from the store when retrieving room for mattermostUserId: %s, err: %v", mattermostUserId, err)
-		return "", errors.New("error getting your room from the store, please contact your system administrator")
+		return "", errors.New(fmt.Sprintf("error getting your room from the store, please contact your system administrator. Err: %v", err))
 	}
 
 	return userInfo.RoomID, nil

--- a/server/user.go
+++ b/server/user.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"errors"
+	"regexp"
+)
+
+type UserInfo struct {
+	RoomID string `json:"room_id"`
+}
+
+func (p *Plugin) getUserFromEmail(email string) (string, error) {
+	rexp := regexp.MustCompile("^(.*)@")
+	matches := rexp.FindStringSubmatch(email)
+	if matches == nil || matches[1] == "" {
+		p.errorf("Error getting userName from email address, address: %v", email)
+		return "", errors.New("error getting userName from email, please contact your system administrator")
+	}
+
+	return matches[1], nil
+}
+
+func (p *Plugin) getRoomOrDefault(mattermostUserId string) (string, error) {
+	userInfo, err := p.store.LoadUserInfo(mattermostUserId)
+	if err == ErrUserNotFound {
+		// expected error
+		user, appErr := p.API.GetUser(mattermostUserId)
+		if appErr != nil {
+			p.errorf("error getting mattermost user from mattermostUserId: %s", mattermostUserId)
+			return "", errors.New("error getting mattermost user from mattermostUserId, please contact your system administrator")
+		}
+
+		// return the default
+		roomId, err2 := p.getUserFromEmail(user.Email)
+		if err2 != nil {
+			return "", err2
+		}
+		return roomId, nil
+	} else if err != nil {
+		// unexpected error
+		p.errorf("error from the store when retrieving room for mattermostUserId: %s, err: %v", mattermostUserId, err)
+		return "", errors.New("error getting your room from the store, please contact your system administrator")
+	}
+
+	return userInfo.RoomID, nil
+}

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,4 +1,4 @@
-# README for Zoom
+# README for Webex (TODO)
 
 Add README information for the webapp portion of your plugin here.
 

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "zoom",
-  "version": "1.0.7",
+  "name": "webex",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "zoom",
-  "version": "1.0.7",
-  "description": "Zoom audio and video conferencing plugin for Mattermost",
+  "name": "webex",
+  "version": "0.0.1",
+  "description": "Webex audio and video conferencing plugin for Mattermost",
   "author": "Mattermost",
   "license": "Apache-2.0",
   "main": "src/index.js",

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -10,15 +10,15 @@ export function startMeeting(channelId) {
         try {
             await Client.startMeeting(channelId, true);
         } catch (error) {
-            let m = 'We could not verify your Mattermost account in Zoom. Please ensure that your Mattermost email address matches your Zoom email address.';
+            let m = 'We could not verify your Mattermost account in Webex. Please ensure that your Mattermost email address matches your Webex email address.';
             if (error.response && error.response.text) {
                 const e = JSON.parse(error.response.text);
                 if (e && e.message) {
-                    m += '\nZoom error: ' + e.message;
+                    m += '\nWebex error: ' + e.message;
                 }
             }
             const post = {
-                id: 'zoomPlugin' + Date.now(),
+                id: 'webexPlugin' + Date.now(),
                 create_at: Date.now(),
                 update_at: 0,
                 edit_at: 0,

--- a/webapp/src/components/post_type_webex/index.js
+++ b/webapp/src/components/post_type_webex/index.js
@@ -12,11 +12,11 @@ import PostTypeWebex from './post_type_webex.jsx';
 
 function mapStateToProps(state, ownProps) {
     const post = ownProps.post || {};
-    const user = state.entities.users.profiles[post.user_id] || {};
+    const user = state.entities.users.profiles[post.props.starting_user_id] || {};
 
     return {
         ...ownProps,
-        creatorName: displayUsernameForUser(user, state.entities.general.config),
+        creatorName: displayUsernameForUser(user, state),
         useMilitaryTime: getBool(state, 'display_settings', 'use_military_time', false),
     };
 }

--- a/webapp/src/components/post_type_webex/post_type_webex.jsx
+++ b/webapp/src/components/post_type_webex/post_type_webex.jsx
@@ -80,34 +80,6 @@ export default class PostTypeWebex extends React.PureComponent {
                     {'JOIN MEETING'}
                 </a>
             );
-
-            if (props.meeting_personal) {
-                subtitle = (
-                    <span>
-                        {'Personal Meeting ID (PMI) : '}
-                        <a
-                            rel='noopener noreferrer'
-                            target='_blank'
-                            href={props.meeting_link}
-                        >
-                            {props.meeting_id}
-                        </a>
-                    </span>
-                );
-            } else {
-                subtitle = (
-                    <span>
-                        {'Meeting ID : '}
-                        <a
-                            rel='noopener noreferrer'
-                            target='_blank'
-                            href={props.meeting_link}
-                        >
-                            {props.meeting_id}
-                        </a>
-                    </span>
-                );
-            }
         } else if (props.meeting_status === 'ENDED') {
             preText = `${this.props.creatorName} has ended the meeting`;
 
@@ -133,7 +105,7 @@ export default class PostTypeWebex extends React.PureComponent {
             );
         }
 
-        let title = 'Zoom Meeting';
+        let title = 'Webex Meeting';
         if (props.meeting_topic) {
             title = props.meeting_topic;
         }

--- a/webapp/src/utils/user_utils.js
+++ b/webapp/src/utils/user_utils.js
@@ -2,10 +2,21 @@
 // See License for license information.
 
 import {getFullName} from 'mattermost-redux/utils/user_utils';
+import {Preferences} from 'mattermost-redux/constants';
+
+function nameDisplaySetting(config) {
+    const key = `${Preferences.CATEGORY_DISPLAY_SETTINGS}--${Preferences.NAME_NAME_FORMAT}`;
+    const prefs = config.entities.preferences.myPreferences;
+    if (!(key in prefs)) {
+        return 'username';
+    }
+
+    return prefs[key].value;
+}
 
 export function displayUsernameForUser(user, config) {
     if (user) {
-        const nameFormat = config.TeammateNameDisplay;
+        const nameFormat = nameDisplaySetting(config);
         let name = user.username;
         if (nameFormat === 'nickname_full_name' && user.nickname && user.nickname !== '') {
             name = user.nickname;


### PR DESCRIPTION
#### Summary
- First big change, not really sure how much of a PR review we can do at this point since a lot of this will change and evolve over time. But any code or architecture pointers/mistakes please let me know!
- Mirrors the functionality of the slack Webex plugin (almost)
- The room defaults to the username portion of the user's email address. If they're using the same email for Mattermost and Webex, this will be their meeting room id. Otherwise they can set their room id with the `/webex room` slash command.
- Needs the admin to set the webex hostname (we then edit it if they add the http or trailing path)
![image](https://user-images.githubusercontent.com/1490756/62794870-3c8fbf80-baa3-11e9-8491-d360f402b617.png)
- /webex commands: help
![image](https://user-images.githubusercontent.com/1490756/62794368-e9693d00-baa1-11e9-8d62-4a554d8117fd.png)
- /webex info:
![image](https://user-images.githubusercontent.com/1490756/62794396-fbe37680-baa1-11e9-94d9-46e7c5cae36d.png)
- /webex room (first setting it, second is without entering a new room name):
![image](https://user-images.githubusercontent.com/1490756/62794469-2a615180-baa2-11e9-9353-7b48d9264dbc.png)
- Click the webex channel icon to start a meeting; a meeting link is presented to everyone in the channel, the host gets a start-meeting ephemeral message:
![image](https://user-images.githubusercontent.com/1490756/62794320-cccd0500-baa1-11e9-8f4f-c333404f68d5.png)

- Next steps:
- [ ] Meeting with slack addon team to learn about the undocumented JSON api they're using
- [ ] Start using the JSON api to pull down the room based on the user's email address (and send an ephemeral message if we couldn't find one)
- [ ] Use proper svg for join meeting button and channel icon

#### Links
- [MM-15374](https://mattermost.atlassian.net/browse/MM-15374)