### PR TITLE
[MM-17761] Use the XML Rest API to create meeting links

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -10,7 +10,8 @@ import (
 const helpText = "###### Mattermost Webex Plugin - Slash Command Help\n" +
 	"* `/webex help` - This help text\n" +
 	"* `/webex info` - Display your current settings\n" +
-	"* `/webex room <room id>` - Set your room id. Meetings you start will use this id. Your room is currently set to: `%s`\n"
+	"* `/webex room <room id>` - Sets your personal Room ID. Meetings you start will use this ID. This setting is required only if your Webex account email address is different from your Mattermost account email address, or if the username of your email does not match your Personal Room ID or User name on your Webex site.\n" +
+	"* `/webex room-reset` - Removes your room setting."
 
 type CommandHandlerFunc func(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse
 
@@ -21,10 +22,11 @@ type CommandHandler struct {
 
 var webexCommandHandler = CommandHandler{
 	handlers: map[string]CommandHandlerFunc{
-		"help":    commandHelp,
-		"info":    executeInfo,
-		"room":    executeRoom,
-		"reqRoom": executeReqRoomId,
+		"help":       commandHelp,
+		"info":       executeInfo,
+		"room":       executeRoom,
+		"room-reset": executeRoomReset,
+		"reqRoom":    executeReqRoomId,
 	},
 	defaultHandler: commandHelp,
 }
@@ -44,11 +46,7 @@ func commandHelp(p *Plugin, c *plugin.Context, header *model.CommandArgs, args .
 }
 
 func (p *Plugin) help(header *model.CommandArgs) *model.CommandResponse {
-	roomId, err := p.getRoomOrDefault(header.UserId)
-	if err != nil {
-		return p.responsef(header, err.Error())
-	}
-	p.postCommandResponse(header, fmt.Sprintf(helpText, roomId))
+	p.postCommandResponse(header, helpText)
 	return &model.CommandResponse{}
 }
 
@@ -66,7 +64,7 @@ func getCommand() *model.Command {
 		DisplayName:      "Webex",
 		Description:      "Integration with Webex.",
 		AutoComplete:     true,
-		AutoCompleteDesc: "Available commands: help, info, room",
+		AutoCompleteDesc: "Available commands: help, info, start, room, room-reset",
 		AutoCompleteHint: "[command]",
 	}
 }
@@ -108,27 +106,37 @@ func executeRoom(p *Plugin, c *plugin.Context, header *model.CommandArgs, args .
 		return p.responsef(header, "error storing user info, please contact your system administrator")
 	}
 
-	return p.responsef(header, "Room is set to: %v", userInfo.RoomID)
+	return p.responsef(header, "Room is set to: `%v`", userInfo.RoomID)
+}
+
+func executeRoomReset(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {
+	userInfo, _ := p.store.LoadUserInfo(header.UserId)
+	userInfo.RoomID = ""
+	err := p.store.StoreUserInfo(header.UserId, userInfo)
+	if err != nil {
+		p.errorf("error in executeRoom: %v", err)
+		return p.responsef(header, "error storing user info, please contact your system administrator")
+	}
+
+	return p.responsef(header, "Room is set to: `<not set>`")
 }
 
 func executeInfo(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {
-	roomId, err := p.getRoomOrDefault(header.UserId)
+	roomId, err := p.getRoom(header.UserId)
 	if err != nil {
 		return p.responsef(header, err.Error())
 	}
+	if roomId == "" {
+		roomId = "<not set>"
+	}
 
-	return p.responsef(header, "Webex site hostname: %s\nYour personal meeting room: %s", p.getConfiguration().SiteHost, roomId)
+	return p.responsef(header, "Webex site hostname: `%s`\nYour personal meeting room: `%s`", p.getConfiguration().SiteHost, roomId)
 }
 
 func executeReqRoomId(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {
-	roomId, err := p.getRoomOrDefault(header.UserId)
+	roomUrl, err := p.getRoomUrl(header.UserId)
 	if err != nil {
 		return p.responsef(header, err.Error())
 	}
-
-	roomUrl, cerr := p.webexClient.GetPersonalMeetingRoomUrl(roomId, "", "")
-	if cerr != nil {
-		return p.responsef(header, "error: %+v", cerr)
-	}
-	return p.responsef(header, "The url is: %s", roomUrl)
+	return p.responsef(header, "The room is: %s", roomUrl)
 }

--- a/server/command.go
+++ b/server/command.go
@@ -133,6 +133,8 @@ func executeInfo(p *Plugin, c *plugin.Context, header *model.CommandArgs, args .
 	return p.responsef(header, "Webex site hostname: `%s`\nYour personal meeting room: `%s`", p.getConfiguration().SiteHost, roomId)
 }
 
+// executeReqRoomId is a quicker way to get the room through the XML API. Not documented for end users.
+// TODO: remove for v1 release.
 func executeReqRoomId(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {
 	roomUrl, err := p.getRoomUrl(header.UserId)
 	if err != nil {

--- a/server/command.go
+++ b/server/command.go
@@ -21,9 +21,10 @@ type CommandHandler struct {
 
 var webexCommandHandler = CommandHandler{
 	handlers: map[string]CommandHandlerFunc{
-		"help": commandHelp,
-		"info": executeInfo,
-		"room": executeRoom,
+		"help":    commandHelp,
+		"info":    executeInfo,
+		"room":    executeRoom,
+		"reqRoom": executeReqRoomId,
 	},
 	defaultHandler: commandHelp,
 }
@@ -117,4 +118,17 @@ func executeInfo(p *Plugin, c *plugin.Context, header *model.CommandArgs, args .
 	}
 
 	return p.responsef(header, "Webex site hostname: %s\nYour personal meeting room: %s", p.getConfiguration().SiteHost, roomId)
+}
+
+func executeReqRoomId(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {
+	roomId, err := p.getRoomOrDefault(header.UserId)
+	if err != nil {
+		return p.responsef(header, err.Error())
+	}
+
+	roomUrl, cerr := p.webexClient.GetPersonalMeetingRoomUrl(roomId, "", "")
+	if cerr != nil {
+		return p.responsef(header, "error: %+v", cerr)
+	}
+	return p.responsef(header, "The url is: %s", roomUrl)
 }

--- a/server/command.go
+++ b/server/command.go
@@ -10,7 +10,7 @@ import (
 const helpText = "###### Mattermost Webex Plugin - Slash Command Help\n" +
 	"* `/webex help` - This help text\n" +
 	"* `/webex info` - Display your current settings\n" +
-	"* `/webex room <room id>` - Sets your personal Room ID. Meetings you start will use this ID. This setting is required only if your Webex account email address is different from your Mattermost account email address, or if the username of your email does not match your Personal Room ID or User name on your Webex site.\n" +
+	"* `/webex room <room id>` - Sets your Personal Meeting Room ID. Meetings you start will use this ID. This setting is required only if your Webex account email address is different from your Mattermost account email address, or if the username of your email does not match your Personal Meeting Room ID or User name on your Webex site.\n" +
 	"* `/webex room-reset` - Removes your room setting."
 
 type CommandHandlerFunc func(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"encoding/json"
+	"github.com/mattermost/mattermost-plugin-webex/server/webex"
 	"reflect"
 	"regexp"
 	"strings"
@@ -25,6 +26,10 @@ import (
 // copy appropriate for your types.
 type configuration struct {
 	SiteHost string `json:"sitehost"`
+
+	// siteName is the SiteHost up to .webex.com
+	// Eg., for testsite.my.webex.com, siteName would be: testsite.my
+	siteName string
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if
@@ -99,7 +104,11 @@ func (p *Plugin) OnConfigurationChange() error {
 		_ = p.API.SavePluginConfig(asMap)
 	}
 
+	configuration.siteName = parseSiteNameFromSiteHost(host)
+
 	p.setConfiguration(configuration)
+
+	p.webexClient = webex.NewClient(configuration.SiteHost, configuration.siteName)
 
 	return nil
 }
@@ -111,4 +120,13 @@ func parseHostFromUrl(url string) string {
 		return matches[1]
 	}
 	return strings.TrimSpace(url)
+}
+
+func parseSiteNameFromSiteHost(siteHost string) string {
+	r := regexp.MustCompile("^(.*?).webex.com")
+	matches := r.FindStringSubmatch(siteHost)
+	if matches != nil {
+		return matches[1]
+	}
+	return ""
 }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -40,8 +40,8 @@ func (c *configuration) Clone() *configuration {
 }
 
 // IsValid checks if all needed fields are set.
-func (c *configuration) IsValid() error {
-	return nil
+func (c *configuration) IsValid() bool {
+	return isValidHostName(c.SiteHost)
 }
 
 // getConfiguration retrieves the active configuration under lock, making it safe to use
@@ -129,4 +129,8 @@ func parseSiteNameFromSiteHost(siteHost string) string {
 		return matches[1]
 	}
 	return ""
+}
+
+func isValidHostName(hostName string) bool {
+	return parseSiteNameFromSiteHost(hostName) != ""
 }

--- a/server/http.go
+++ b/server/http.go
@@ -83,8 +83,10 @@ func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) (int
 		return http.StatusInternalServerError, err
 	}
 
-	siteHost := p.getConfiguration().SiteHost
-	if siteHost == "" {
+	config := p.getConfiguration()
+	siteHost := config.SiteHost
+	siteName := config.siteName
+	if siteHost == "" || siteName == "" {
 		return http.StatusInternalServerError, errors.New("Unable to setup a meeting; the Webex plugin has not been configured yet.\nPlease ask your system administrator to set the `Webex Site Hostname` in `System Console -> PLUGINS -> Webex`.")
 	}
 

--- a/server/http.go
+++ b/server/http.go
@@ -65,7 +65,7 @@ func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) (int
 	}
 
 	if !p.getConfiguration().IsValid() {
-		return http.StatusInternalServerError, errors.New("Unable to setup a meeting; the Webex plugin has not been configured correctly.")
+		return http.StatusInternalServerError, errors.New("Unable to setup a meeting; the Webex plugin has not been configured correctly.  Please speak with your Mattermost administrator.")
 	}
 
 	var req startMeetingRequest

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -32,6 +32,10 @@ func TestPlugin(t *testing.T) {
 		strings.NewReader("{\"channel_id\": \"thechannelid\"}"))
 	validMeetingRequest2.Header.Add("Mattermost-User-Id", "theuserid")
 
+	validMeetingRequest3 := httptest.NewRequest("POST", "/api/v1/meetings",
+		strings.NewReader("{\"channel_id\": \"thechannelid\"}"))
+	validMeetingRequest3.Header.Add("Mattermost-User-Id", "theuserid")
+
 	invalidMeetingRequestGet := httptest.NewRequest("GET", "/api/v1/meetings",
 		strings.NewReader("{\"channel_id\": \"thechannelid\"}"))
 	invalidMeetingRequestGet.Header.Add("Mattermost-User-Id", "theuserid")
@@ -62,6 +66,12 @@ func TestPlugin(t *testing.T) {
 			Name:               "No SiteHost set",
 			Request:            validMeetingRequest2,
 			SiteHost:           "",
+			ExpectedStatusCode: http.StatusInternalServerError,
+		},
+		{
+			Name:               "Invalid SiteHost set",
+			Request:            validMeetingRequest3,
+			SiteHost:           "blah.blah.webex.co",
 			ExpectedStatusCode: http.StatusInternalServerError,
 		},
 		{
@@ -128,6 +138,7 @@ func TestPlugin(t *testing.T) {
 			p := Plugin{}
 			p.setConfiguration(&configuration{
 				SiteHost: tc.SiteHost,
+				siteName: parseSiteNameFromSiteHost(tc.SiteHost),
 			})
 			p.SetAPI(api)
 

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -153,7 +153,7 @@ func TestPlugin(t *testing.T) {
 			err = p.OnActivate()
 			require.Nil(t, err)
 
-			p.webexClient = webex.MockClient{tc.SiteHost}
+			p.webexClient = webex.MockClient{SiteHost: tc.SiteHost}
 
 			w := httptest.NewRecorder()
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/mattermost/mattermost-plugin-webex/server/webex"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
@@ -38,6 +39,9 @@ type Plugin struct {
 
 	// KV store
 	store Store
+
+	// the http client
+	webexClient *webex.Client
 }
 
 // OnActivate checks if the configurations is valid and ensures the bot account exists
@@ -77,6 +81,8 @@ func (p *Plugin) OnActivate() error {
 	if err != nil {
 		return errors.WithMessage(err, "OnActivate: failed to register command")
 	}
+
+	p.webexClient = webex.NewClient(config.SiteHost, config.siteName)
 
 	return nil
 }

--- a/server/store_mock_test.go
+++ b/server/store_mock_test.go
@@ -6,5 +6,5 @@ func (store mockStore) StoreUserInfo(mattermostUserId string, info UserInfo) err
 	return nil
 }
 func (store mockStore) LoadUserInfo(mattermostUserId string) (UserInfo, error) {
-	return UserInfo{}, nil
+	return UserInfo{RoomID: "myroom", Email: "myemail@host.com"}, nil
 }

--- a/server/user.go
+++ b/server/user.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 type UserInfo struct {
+	Email  string `json:"email"`
 	RoomID string `json:"room_id"`
 }
 
@@ -21,27 +23,109 @@ func (p *Plugin) getUserFromEmail(email string) (string, error) {
 	return matches[1], nil
 }
 
+func (p *Plugin) makeJoinUrl(meetingUrl string) string {
+	return strings.Replace(meetingUrl, "webex.com/meet/", "webex.com/join/", 1)
+}
+
+func (p *Plugin) makeStartUrl(meetingUrl string) string {
+	return strings.Replace(meetingUrl, "webex.com/meet/", "webex.com/start/", 1)
+}
+
+func (p *Plugin) getEmailAndEmailName(mattermostUserId string) (string, string, error) {
+	user, appErr := p.API.GetUser(mattermostUserId)
+	if appErr != nil {
+		p.errorf("error getting mattermost user from mattermostUserId: %s", mattermostUserId)
+		return "", "", errors.New("error getting mattermost user from mattermostUserId, please contact your system administrator")
+	}
+	emailName, err := p.getUserFromEmail(user.Email)
+	if err != nil {
+		return "", "", err
+	}
+
+	return user.Email, emailName, nil
+}
+
+func (p *Plugin) getUrlFromRoom(mattermostUserId string) (string, error) {
+	userInfo, err := p.store.LoadUserInfo(mattermostUserId)
+	if err == ErrUserNotFound {
+		return "", err
+	}
+	if err != nil {
+		// unexpected error
+		p.errorf("error from the store when retrieving room for mattermostUserId: %s, error: %v", mattermostUserId, err)
+		return "", errors.New(fmt.Sprintf("error getting your room from the store, please contact your system administrator. Error: %v", err))
+	}
+
+	roomUrl, cerr := p.webexClient.GetPersonalMeetingRoomUrl(userInfo.RoomID, "", "")
+	if cerr != nil {
+		return "", cerr
+	}
+
+	return roomUrl, nil
+}
+
+func (p *Plugin) getUrlFromEmail(mattermostUserId string) (string, error) {
+	email, emailName, err := p.getEmailAndEmailName(mattermostUserId)
+	if err != nil {
+		return "", err
+	}
+	roomUrl, cerr := p.webexClient.GetPersonalMeetingRoomUrl("", emailName, email)
+	if cerr != nil {
+		return "", cerr.Err
+	}
+
+	return roomUrl, nil
+}
+
 func (p *Plugin) getRoomOrDefault(mattermostUserId string) (string, error) {
 	userInfo, err := p.store.LoadUserInfo(mattermostUserId)
 	if err == ErrUserNotFound {
 		// expected error
-		user, appErr := p.API.GetUser(mattermostUserId)
-		if appErr != nil {
-			p.errorf("error getting mattermost user from mattermostUserId: %s", mattermostUserId)
-			return "", errors.New("error getting mattermost user from mattermostUserId, please contact your system administrator")
-		}
-
-		// return the default
-		roomId, err2 := p.getUserFromEmail(user.Email)
+		_, emailName, err2 := p.getEmailAndEmailName(mattermostUserId)
 		if err2 != nil {
 			return "", err2
 		}
-		return roomId, nil
+		return emailName, nil
 	} else if err != nil {
 		// unexpected error
-		p.errorf("error from the store when retrieving room for mattermostUserId: %s, err: %v", mattermostUserId, err)
-		return "", errors.New(fmt.Sprintf("error getting your room from the store, please contact your system administrator. Err: %v", err))
+		p.errorf("error from the store when retrieving room for mattermostUserId: %s, error: %v", mattermostUserId, err)
+		return "", errors.New(fmt.Sprintf("error retrieving your room from the store, please contact your system administrator. Error: %v", err))
 	}
 
 	return userInfo.RoomID, nil
+}
+
+func (p *Plugin) getRoom(mattermostUserId string) (string, error) {
+	userInfo, err := p.store.LoadUserInfo(mattermostUserId)
+	if err != nil {
+		return "", err
+	}
+	return userInfo.RoomID, nil
+}
+
+// getRoomUrl will find the correct url for mattermostUserId, or return a message explaining why it couldn't.
+func (p *Plugin) getRoomUrl(mattermostUserId string) (string, error) {
+	email, emailName, err := p.getEmailAndEmailName(mattermostUserId)
+	if err != nil {
+		return "", fmt.Errorf("Error getting email and emailName: %v", err)
+	}
+	roomId, err := p.getRoom(mattermostUserId)
+	if err == nil && roomId != "" {
+		// Look for their url using roomId
+		roomUrl, err := p.getUrlFromRoom(mattermostUserId)
+		if err != nil {
+			return "", fmt.Errorf("No Personal Room link found at `%s` for your room: `%s`", p.getConfiguration().SiteHost, roomId)
+		}
+
+		return roomUrl, nil
+	}
+
+	// Look for their url using userName or email
+	roomUrl, err := p.getUrlFromEmail(mattermostUserId)
+	if err != nil {
+		return "", fmt.Errorf("No Personal Room link found at `%s` for your userName: `%s`, or your email: `%s`", p.getConfiguration().SiteHost, emailName, email)
+	}
+
+	return roomUrl, nil
+
 }

--- a/server/user.go
+++ b/server/user.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 )
 
@@ -39,7 +40,7 @@ func (p *Plugin) getRoomOrDefault(mattermostUserId string) (string, error) {
 	} else if err != nil {
 		// unexpected error
 		p.errorf("error from the store when retrieving room for mattermostUserId: %s, err: %v", mattermostUserId, err)
-		return "", errors.New("error getting your room from the store, please contact your system administrator")
+		return "", errors.New(fmt.Sprintf("error getting your room from the store, please contact your system administrator. Err: %v", err))
 	}
 
 	return userInfo.RoomID, nil

--- a/server/user.go
+++ b/server/user.go
@@ -56,9 +56,9 @@ func (p *Plugin) getUrlFromRoom(mattermostUserId string) (string, error) {
 		return "", errors.New(fmt.Sprintf("error getting your room from the store, please contact your system administrator. Error: %v", err))
 	}
 
-	roomUrl, cerr := p.webexClient.GetPersonalMeetingRoomUrl(userInfo.RoomID, "", "")
-	if cerr != nil {
-		return "", cerr
+	roomUrl, err := p.webexClient.GetPersonalMeetingRoomUrl(userInfo.RoomID, "", "")
+	if err != nil {
+		return "", err
 	}
 
 	return roomUrl, nil
@@ -69,9 +69,9 @@ func (p *Plugin) getUrlFromEmail(mattermostUserId string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	roomUrl, cerr := p.webexClient.GetPersonalMeetingRoomUrl("", emailName, email)
-	if cerr != nil {
-		return "", cerr.Err
+	roomUrl, err := p.webexClient.GetPersonalMeetingRoomUrl("", emailName, email)
+	if err != nil {
+		return "", err
 	}
 
 	return roomUrl, nil
@@ -112,8 +112,8 @@ func (p *Plugin) getRoomUrl(mattermostUserId string) (string, error) {
 	roomId, err := p.getRoom(mattermostUserId)
 	if err == nil && roomId != "" {
 		// Look for their url using roomId
-		roomUrl, err := p.getUrlFromRoom(mattermostUserId)
-		if err != nil {
+		roomUrl, err2 := p.getUrlFromRoom(mattermostUserId)
+		if err2 != nil {
 			return "", fmt.Errorf("No Personal Room link found at `%s` for your room: `%s`", p.getConfiguration().SiteHost, roomId)
 		}
 

--- a/server/user.go
+++ b/server/user.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"regexp"
 )
 
@@ -40,7 +39,7 @@ func (p *Plugin) getRoomOrDefault(mattermostUserId string) (string, error) {
 	} else if err != nil {
 		// unexpected error
 		p.errorf("error from the store when retrieving room for mattermostUserId: %s, err: %v", mattermostUserId, err)
-		return "", errors.New(fmt.Sprintf("error getting your room from the store, please contact your system administrator. Err: %v", err))
+		return "", errors.New("error getting your room from the store, please contact your system administrator")
 	}
 
 	return userInfo.RoomID, nil

--- a/server/webex/client.go
+++ b/server/webex/client.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License for license information.
+
+package webex
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+type ClientError struct {
+	StatusCode int
+	Err        error
+}
+
+func (ce *ClientError) Error() string {
+	return ce.Err.Error()
+}
+
+// Client represents a Webex API client
+type Client struct {
+	httpClient *http.Client
+	xmlURL     string
+	siteName   string
+}
+
+// NewClient returns a new Webex XML API client.
+func NewClient(siteHost, siteName string) *Client {
+	webexURL := (&url.URL{
+		Scheme: "https",
+		Host:   siteHost,
+		Path:   "/WBXService/XMLService",
+	}).String()
+
+	return &Client{
+		httpClient: &http.Client{},
+		xmlURL:     webexURL,
+		siteName:   siteName,
+	}
+}
+
+// GetPersonalMeetingRoomUrl prefers roomId, username, and email for finding the PMR url (in that order).
+func (c *Client) GetPersonalMeetingRoomUrl(roomId, username, email string) (string, *ClientError) {
+	if roomId != "" {
+		pmrUrl, err := c.getPMRFromRoomId(roomId)
+		if err == nil && pmrUrl != "" {
+			return pmrUrl, nil
+		}
+	}
+	if username != "" {
+		pmrUrl, err := c.getPMRFromUserName(username)
+		if err == nil && pmrUrl != "" {
+			return pmrUrl, nil
+		}
+	}
+	if email != "" {
+		pmrUrl, err := c.getPMRFromEmail(email)
+		if err == nil && pmrUrl != "" {
+			return pmrUrl, nil
+		}
+	}
+
+	return "", &ClientError{500, errors.New("couldn't get PMR url")}
+}
+
+const payloadWrapper = `<?xml version="1.0" encoding="UTF-8"?>
+<serv:message xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <header>
+        <securityContext>
+            <siteName>%s</siteName>
+        </securityContext>
+    </header>
+    <body>
+        <bodyContent xsi:type="java:com.webex.service.binding.user.GetUserCard">
+            %s
+        </bodyContent>
+    </body>
+</serv:message>`
+
+const roomIdContent = `<personalUrl>%s</personalUrl>`
+const webexIdContent = `<webExId>%s</webExId>`
+const emailContent = `<email>%s</email>`
+
+func (c *Client) getPMRFromRoomId(roomId string) (string, *ClientError) {
+	content := fmt.Sprintf(roomIdContent, roomId)
+	payload := fmt.Sprintf(payloadWrapper, c.siteName, content)
+
+	buf, cerr := c.request(payload)
+	if cerr != nil {
+		return "", cerr
+	}
+
+	var message GetPMRR
+	err := xml.Unmarshal(buf.Bytes(), &message)
+	if err != nil {
+		return "", &ClientError{http.StatusInternalServerError, err}
+	}
+
+	return message.Body.BodyContent.PersonalMeetingRoom.PMRUrl, nil
+}
+
+func (c *Client) getPMRFromUserName(roomId string) (string, *ClientError) {
+	return "", nil
+}
+
+func (c *Client) getPMRFromEmail(roomId string) (string, *ClientError) {
+	return "", nil
+}
+
+func (c *Client) request(payload string) (*bytes.Buffer, *ClientError) {
+	rq, err := http.NewRequest("POST", c.xmlURL, bytes.NewReader([]byte(payload)))
+	if err != nil {
+		return nil, &ClientError{http.StatusInternalServerError, err}
+	}
+	rq.Header.Set("Content-Type", "text/xml")
+	rq.Close = true
+
+	rp, err := c.httpClient.Do(rq)
+
+	if err != nil {
+		return nil, &ClientError{
+			http.StatusInternalServerError,
+			errors.WithMessagef(err, "failed request to %v", c.xmlURL),
+		}
+	}
+
+	if rp == nil {
+		return nil, &ClientError{
+			http.StatusInternalServerError,
+			errors.Errorf("received nil response when making request to %v", c.xmlURL),
+		}
+	}
+
+	defer closeBody(rp)
+
+	if rp.StatusCode >= 300 {
+		return nil, &ClientError{
+			rp.StatusCode,
+			errors.New("Received status code above 300")}
+	}
+
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(rp.Body)
+	if err != nil {
+		return nil, &ClientError{
+			http.StatusInternalServerError,
+			errors.Errorf("Failed to read response from %v", c.xmlURL),
+		}
+	}
+
+	return buf, nil
+}
+
+func closeBody(r *http.Response) {
+	if r.Body != nil {
+		ioutil.ReadAll(r.Body)
+		r.Body.Close()
+	}
+}

--- a/server/webex/webex_xml_types.go
+++ b/server/webex/webex_xml_types.go
@@ -14,17 +14,16 @@ type GetPMRRBody struct {
 }
 
 type GetPMRRBodyContent struct {
-	XMLName             xml.Name      `xml:"bodyContent"`
-	Avatar              GetPMRRAvatar `xml:"avatar"`
-	PersonalMeetingRoom PMR           `xml:"personalMeetingRoom"`
-	//HostMeetingURL string        `xml:"hostMeetingURL"`
+	XMLName             xml.Name `xml:"bodyContent"`
+	Avatar              Avatar   `xml:"avatar"`
+	PersonalMeetingRoom PMR      `xml:"personalMeetingRoom"`
 }
 
-type GetPMRRAvatar struct {
-	//XMLName          xml.Name `xml:"avatar"`
-	Url              string `xml:"url"`
-	LastModifiedTime int    `xml:"lastModifiedTime"`
-	IsUploaded       bool   `xml:"isUploaded"`
+type Avatar struct {
+	XMLName          xml.Name `xml:"avatar"`
+	Url              string   `xml:"url"`
+	LastModifiedTime int      `xml:"lastModifiedTime"`
+	IsUploaded       bool     `xml:"isUploaded"`
 }
 
 type PMR struct {

--- a/server/webex/webex_xml_types.go
+++ b/server/webex/webex_xml_types.go
@@ -1,0 +1,45 @@
+package webex
+
+import "encoding/xml"
+
+// PMRR = PersonalMeetingRoomResponse
+type GetPMRR struct {
+	XMLName xml.Name    `xml:"message"`
+	Header  Header      `xml:"header"`
+	Body    GetPMRRBody `xml:"body"`
+}
+
+type GetPMRRBody struct {
+	BodyContent GetPMRRBodyContent `xml:"bodyContent"`
+}
+
+type GetPMRRBodyContent struct {
+	XMLName             xml.Name      `xml:"bodyContent"`
+	Avatar              GetPMRRAvatar `xml:"avatar"`
+	PersonalMeetingRoom PMR           `xml:"personalMeetingRoom"`
+	//HostMeetingURL string        `xml:"hostMeetingURL"`
+}
+
+type GetPMRRAvatar struct {
+	//XMLName          xml.Name `xml:"avatar"`
+	Url              string `xml:"url"`
+	LastModifiedTime int    `xml:"lastModifiedTime"`
+	IsUploaded       bool   `xml:"isUploaded"`
+}
+
+type PMR struct {
+	XMLName    xml.Name `xml:"personalMeetingRoom"`
+	Title      string   `xml:"title"`
+	PMRUrl     string   `xml:"personalMeetingRoomURL"`
+	AccessCode string   `xml:"accessCode"`
+}
+
+type Header struct {
+	XMLName  xml.Name `xml:"header"`
+	Response Response `xml:"response"`
+}
+
+type Response struct {
+	XMLName xml.Name `xml:"response"`
+	Result  string   `xml:"result"`
+}

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -10,6 +10,9 @@ export function startMeeting(channelId) {
         try {
             await Client.startMeeting(channelId, true);
         } catch (error) {
+            if (error.response && error.response.statusCode === 400) {
+                return {error};
+            }
             let m = 'We could not verify your Mattermost account in Webex. Please ensure that your Mattermost email address matches your Webex email address.';
             if (error.response && error.response.text) {
                 const e = JSON.parse(error.response.text);

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -10,40 +10,34 @@ export function startMeeting(channelId) {
         try {
             await Client.startMeeting(channelId, true);
         } catch (error) {
-            if (error.response && error.response.statusCode === 400) {
-                return {error};
-            }
-            let m = 'We could not verify your Mattermost account in Webex. Please ensure that your Mattermost email address matches your Webex email address.';
             if (error.response && error.response.text) {
-                const e = JSON.parse(error.response.text);
-                if (e && e.message) {
-                    m += '\nWebex error: ' + e.message;
-                }
-            }
-            const post = {
-                id: 'webexPlugin' + Date.now(),
-                create_at: Date.now(),
-                update_at: 0,
-                edit_at: 0,
-                delete_at: 0,
-                is_pinned: false,
-                user_id: getState().entities.users.currentUserId,
-                channel_id: channelId,
-                root_id: '',
-                parent_id: '',
-                original_id: '',
-                message: m,
-                type: 'system_ephemeral',
-                props: {},
-                hashtags: '',
-                pending_post_id: '',
-            };
+                let m = 'We could not start a meeting.';
+                m += '\nWebex error: ' + error.response.text;
+                const post = {
+                    id: 'webexPlugin' + Date.now(),
+                    create_at: Date.now(),
+                    update_at: 0,
+                    edit_at: 0,
+                    delete_at: 0,
+                    is_pinned: false,
+                    user_id: getState().entities.users.currentUserId,
+                    channel_id: channelId,
+                    root_id: '',
+                    parent_id: '',
+                    original_id: '',
+                    message: m,
+                    type: 'system_ephemeral',
+                    props: {},
+                    hashtags: '',
+                    pending_post_id: '',
+                };
 
-            dispatch({
-                type: PostTypes.RECEIVED_NEW_POST,
-                data: post,
-                channelId,
-            });
+                dispatch({
+                    type: PostTypes.RECEIVED_NEW_POST,
+                    data: post,
+                    channelId,
+                });
+            }
 
             return {error};
         }


### PR DESCRIPTION
#### Summary
- Uses the XML endpoints provided by the Cisco slack addon team to find if a room is valid
- If a user has a custom roomId set (through the slash command) it will try to find that room. If it can't, it will fail and explain why. The user will then want to change their roomId or reset it.
- If there is no roomId, we will try to find their room based on their email or their email username. If it can't, it will fail and explain why.
- This is very close to the Slack addon's functionality (just a few more slash commands and we'll be there -- those are on my board.) At least, before they added the scheduling functionality last week.

PM UX:
![image](https://user-images.githubusercontent.com/1490756/63443303-8a40ec00-c402-11e9-8a76-1a5962bad0d3.png)
![image](https://user-images.githubusercontent.com/1490756/63443325-93ca5400-c402-11e9-8ab3-a538e6e7062c.png)
![image](https://user-images.githubusercontent.com/1490756/63443333-99c03500-c402-11e9-9cd1-b9512c1dcf9d.png)
![image](https://user-images.githubusercontent.com/1490756/63443355-a5136080-c402-11e9-99b3-229fa39c98c0.png)

#### Links
[MM-17761](https://mattermost.atlassian.net/browse/MM-17761)