### PR TITLE
Use MM username, not email username

### DIFF
--- a/server/http_test.go
+++ b/server/http_test.go
@@ -124,14 +124,6 @@ func TestPlugin(t *testing.T) {
 			Room:               "myroom",
 		},
 		{
-			Name:               "Invalid meeting request: user has no roomId set, using their email. Invalid email.",
-			Request:            validMeetingRequest5,
-			SiteHost:           "hostname.webex.com",
-			ExpectedStatusCode: http.StatusBadRequest,
-			User:               UserInfo{Email: "myemailtestcom", RoomID: ""},
-			Room:               "myemail",
-		},
-		{
 			Name:               "Valid meeting request: user has no email, but roomId is set.",
 			Request:            validMeetingRequest6,
 			SiteHost:           "hostname.webex.com",

--- a/server/meeting.go
+++ b/server/meeting.go
@@ -87,8 +87,8 @@ func (p *Plugin) getUrlFromRoomId(roomId string) (string, error) {
 	return roomUrl, nil
 }
 
-func (p *Plugin) getUrlFromNameOrEmail(emailName, email string) (string, error) {
-	roomUrl, err := p.webexClient.GetPersonalMeetingRoomUrl("", emailName, email)
+func (p *Plugin) getUrlFromNameOrEmail(userName, email string) (string, error) {
+	roomUrl, err := p.webexClient.GetPersonalMeetingRoomUrl("", userName, email)
 	if err != nil {
 		return "", err
 	}
@@ -107,13 +107,13 @@ func (p *Plugin) getRoomUrlFromMMId(mattermostUserId string) (string, error) {
 		}
 	} else {
 		// Look for their url using userName or email
-		email, emailName, err := p.getEmailAndEmailName(mattermostUserId)
+		email, userName, err := p.getEmailAndUserName(mattermostUserId)
 		if err != nil {
-			return "", fmt.Errorf("Error getting email and emailName: %v", err)
+			return "", fmt.Errorf("Error getting email and Username: %v", err)
 		}
-		roomUrl, err = p.getUrlFromNameOrEmail(emailName, email)
+		roomUrl, err = p.getUrlFromNameOrEmail(userName, email)
 		if err != nil {
-			return "", fmt.Errorf("No Personal Room link found at `%s` for your userName: `%s`, or your email: `%s`. Try setting a room manually with `/webex room <room id>`.", p.getConfiguration().SiteHost, emailName, email)
+			return "", fmt.Errorf("No Personal Room link found at `%s` for your Username: `%s`, or your email: `%s`. Try setting a room manually with `/webex room <room id>`.", p.getConfiguration().SiteHost, userName, email)
 		}
 	}
 

--- a/server/store.go
+++ b/server/store.go
@@ -65,7 +65,7 @@ func (store store) set(key string, v interface{}) error {
 
 func (store store) StoreUserInfo(mattermostUserId string, info UserInfo) error {
 	// Set the email because we need a field in the userInfo that cannot be blank (in order to tell if a user was found)
-	email, _, err := store.plugin.getEmailAndEmailName(mattermostUserId)
+	email, _, err := store.plugin.getEmailAndUserName(mattermostUserId)
 	if err != nil {
 		return err
 	}

--- a/webapp/src/components/icon.jsx
+++ b/webapp/src/components/icon.jsx
@@ -3,8 +3,6 @@
 
 import React from 'react';
 
-import {makeStyleFromTheme} from 'mattermost-redux/utils/theme_utils';
-
 import {Svgs} from '../constants';
 
 export default class Icon extends React.PureComponent {


### PR DESCRIPTION
#### Summary
Last-minute update to Webex backend and UI. The system now looks for the room associated with the user's MM username. Before, it looked for the username portion of the user's email.

UI now looks like:
![image](https://user-images.githubusercontent.com/1490756/65797050-37163380-e13c-11e9-8c28-a2e01a35666d.png)

#### Links
- No ticket, came from feedback from Dylan. Thanks @DHaussermann !