### PR TITLE
5.11 compatible

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
     "name": "Webex",
     "description": "Webex audio and video conferencing plugin for Mattermost.",
     "version": "0.0.1",
-    "min_server_version": "5.12.0",
+    "min_server_version": "5.11.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",


### PR DESCRIPTION
Christopher: since you wrote ensure bot, I just wanted to have your sign off -- I'm requiring 5.12 for ensurebot, but if that's all I'm using from helpers (and a bunch of the older APIs for the rest), then this should work for 5.11, correct? One of our customers is stuck on 5.11 for awhile.