### PR TITLE
[GH-27] Post meeting messages as a user rather than a bot

### DIFF
--- a/server/http_test.go
+++ b/server/http_test.go
@@ -210,7 +210,7 @@ func TestPlugin(t *testing.T) {
 
 			webexJoinURL := "https://" + tc.SiteHost + "/join/" + tc.Room
 			expectedJoinPost := &model.Post{
-				UserId:    p.botUserID,
+				UserId:    "theuserid",
 				ChannelId: "thechannelid",
 				Message:   fmt.Sprintf("Meeting started at %s.", webexJoinURL),
 				Type:      "custom_webex",

--- a/server/meeting.go
+++ b/server/meeting.go
@@ -41,7 +41,7 @@ func (p *Plugin) startMeetingFromRoomURL(details meetingDetails) (*meetingPosts,
 	webexStartURL := p.makeStartURL(details.roomURL)
 
 	joinPost := &model.Post{
-		UserId:    p.botUserID,
+		UserId:    details.startedByUserID,
 		ChannelId: details.channelID,
 		Message:   fmt.Sprintf("Meeting started at %s.", webexJoinURL),
 		Type:      "custom_webex",

--- a/webapp/src/components/post_type_webex/index.js
+++ b/webapp/src/components/post_type_webex/index.js
@@ -16,6 +16,7 @@ function mapStateToProps(state, ownProps) {
 
     return {
         ...ownProps,
+        fromBot: ownProps.post.props.from_bot,
         creatorName: displayUsernameForUser(user, state),
         useMilitaryTime: getBool(state, 'display_settings', 'use_military_time', false),
     };

--- a/webapp/src/components/post_type_webex/post_type_webex.jsx
+++ b/webapp/src/components/post_type_webex/post_type_webex.jsx
@@ -41,6 +41,11 @@ export default class PostTypeWebex extends React.PureComponent {
          * Creator's name.
          */
         creatorName: PropTypes.string.isRequired,
+
+        /**
+         * Whether the post was sent from a bot. Used for backwards compatibility.
+         */
+        fromBot: PropTypes.bool.isRequired,
     };
 
     static defaultProps = {
@@ -62,9 +67,10 @@ export default class PostTypeWebex extends React.PureComponent {
 
         let content;
         let subtitle;
-        let preText = `${this.props.creatorName} has started a meeting`;
+        const subject = this.props.fromBot ? `${this.props.creatorName} has` : 'I have';
+        let preText = `${subject} started a meeting`;
         if (props.meeting_status === 'INVITED') {
-            preText = `${this.props.creatorName} has invited you to a meeting`;
+            preText = `${subject} invited you to a meeting`;
         }
         if (props.meeting_status === 'STARTED' || props.meeting_status === 'INVITED') {
             content = (
@@ -84,7 +90,7 @@ export default class PostTypeWebex extends React.PureComponent {
                 </a>
             );
         } else if (props.meeting_status === 'ENDED') {
-            preText = `${this.props.creatorName} has ended the meeting`;
+            preText = `${subject} ended the meeting`;
 
             if (props.meeting_personal) {
                 subtitle = 'Personal Meeting ID (PMI) : ' + props.meeting_id;


### PR DESCRIPTION
#### Summary
Post messages with links to meetings from the user who started the meeting, rather than the webex bot. This allows the user to delete past meeting invites as required.
Implementation was taken from https://github.com/mattermost/mattermost-plugin-zoom/pull/112

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-webex/issues/27