### PR TITLE
Add a settings to control URL substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Go to Settings --> Scroll down to the Plugins section, and click on Webex Plugin
 
 Insert the Webex Meetings URL for your organization. It is often in the format of `<companyname>.my.webex.com` or `<companyname>.webex.com`.
 
+Depending on your situation, you will want to disable the URL conversion (known unsupported on some case with Linux clients).
+
 ## Usage
 Easily start and join Webex meetings directly from Mattermost
 

--- a/plugin.json
+++ b/plugin.json
@@ -30,6 +30,13 @@
                 "help_text": "The hostname for your team's Webex site. For example: teamsite.webex.com.",
                 "placeholder": "teamsite.webex.com",
                 "default": null
+            },
+            {
+                "key": "UrlConversion",
+                "display_name": "Convert Webex URLs:",
+                "type": "bool",
+                "help_text": "Enable or disable the conversion of URL: replace /meet/ by /join/ or /start/.",
+                "default": true
             }
         ]
     }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -28,7 +28,7 @@ import (
 type configuration struct {
 	SiteHost string `json:"sitehost"`
 
-	UrlConversion bool `json:"UrlConversion"`
+	URLConversion bool `json:"url_conversion"`
 
 	// siteName is the SiteHost up to .webex.com
 	// Eg., for testsite.my.webex.com, siteName would be: testsite.my

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -28,6 +28,8 @@ import (
 type configuration struct {
 	SiteHost string `json:"sitehost"`
 
+	UrlConversion bool `json:"UrlConversion"`
+
 	// siteName is the SiteHost up to .webex.com
 	// Eg., for testsite.my.webex.com, siteName would be: testsite.my
 	siteName string

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -184,8 +184,9 @@ func TestPlugin(t *testing.T) {
 
 			p := Plugin{}
 			p.setConfiguration(&configuration{
-				SiteHost: tc.SiteHost,
-				siteName: parseSiteNameFromSiteHost(tc.SiteHost),
+				SiteHost:      tc.SiteHost,
+				siteName:      parseSiteNameFromSiteHost(tc.SiteHost),
+				URLConversion: true,
 			})
 			p.SetAPI(api)
 

--- a/server/meeting.go
+++ b/server/meeting.go
@@ -73,11 +73,19 @@ func (p *Plugin) startMeetingFromRoomURL(details meetingDetails) (*meetingPosts,
 }
 
 func (p *Plugin) makeJoinURL(meetingURL string) string {
-	return strings.Replace(meetingURL, "webex.com/meet/", "webex.com/join/", 1)
+	if p.getConfiguration().UrlConversion {
+		return strings.Replace(meetingURL, "webex.com/meet/", "webex.com/join/", 1)
+	} else {
+		return meetingURL
+	}
 }
 
 func (p *Plugin) makeStartURL(meetingURL string) string {
-	return strings.Replace(meetingURL, "webex.com/meet/", "webex.com/start/", 1)
+	if p.getConfiguration().UrlConversion {
+		return strings.Replace(meetingURL, "webex.com/meet/", "webex.com/start/", 1)
+	} else {
+		return meetingURL
+	}
 }
 
 func (p *Plugin) getURLFromRoomID(roomID string) (string, error) {

--- a/server/meeting.go
+++ b/server/meeting.go
@@ -73,19 +73,19 @@ func (p *Plugin) startMeetingFromRoomURL(details meetingDetails) (*meetingPosts,
 }
 
 func (p *Plugin) makeJoinURL(meetingURL string) string {
-	if p.getConfiguration().UrlConversion {
-		return strings.Replace(meetingURL, "webex.com/meet/", "webex.com/join/", 1)
-	} else {
-		return meetingURL
+	if p.getConfiguration().URLConversion {
+		meetingURL = strings.Replace(meetingURL, "webex.com/meet/", "webex.com/join/", 1)
 	}
+
+	return meetingURL
 }
 
 func (p *Plugin) makeStartURL(meetingURL string) string {
-	if p.getConfiguration().UrlConversion {
-		return strings.Replace(meetingURL, "webex.com/meet/", "webex.com/start/", 1)
-	} else {
-		return meetingURL
+	if p.getConfiguration().URLConversion {
+		meetingURL = strings.Replace(meetingURL, "webex.com/meet/", "webex.com/start/", 1)
 	}
+
+	return meetingURL
 }
 
 func (p *Plugin) getURLFromRoomID(roomID string) (string, error) {


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This substitution is known to break Linux experience.
While the raw URL is also known to work on Windows.

In some circumstance, it could be desirable to not substitute
URLs.

#### Ticket Link
Fixes #31 

