### PR TITLE
solves GH 54 - WebEx text is missing white space when plugins are icons are in collapsed list

### DIFF
--- a/webapp/src/components/icon.jsx
+++ b/webapp/src/components/icon.jsx
@@ -9,7 +9,7 @@ export default class Icon extends React.PureComponent {
     render() {
         return (
             <span
-                className='d-flex align-items-center overflow--ellipsis'
+                className='d-flex align-items-center overflow--ellipsis icon'
                 aria-hidden='true'
                 dangerouslySetInnerHTML={{__html: Svgs.WEBEX_ICON}}
             />


### PR DESCRIPTION
#### Summary
WebEx text is missing white space when plugins are icons are in collapsed list
#### Ticket Link
https://github.com/mattermost/mattermost-plugin-webex/issues/54