### PR TITLE
fix: move getServerRoute to selectors module to avoid TDZ on plugin init

### DIFF
--- a/webapp/src/index.js
+++ b/webapp/src/index.js
@@ -11,6 +11,7 @@ import Icon from './components/icon.jsx';
 import PostTypeWebex from './components/post_type_webex';
 import {startMeeting} from './actions';
 import Client from './client';
+import {getServerRoute} from './selectors';
 
 const {id: pluginId} = manifest;
 
@@ -39,18 +40,3 @@ class Plugin {
 }
 
 window.registerPlugin(pluginId, new Plugin());
-
-const getServerRoute = (state) => {
-    const config = getConfig(state);
-
-    let basePath = '';
-    if (config && config.SiteURL) {
-        basePath = new URL(config.SiteURL).pathname;
-
-        if (basePath && basePath[basePath.length - 1] === '/') {
-            basePath = basePath.substr(0, basePath.length - 1);
-        }
-    }
-
-    return basePath;
-};

--- a/webapp/src/index.test.js
+++ b/webapp/src/index.test.js
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/* eslint-disable max-nested-callbacks */
+
+jest.mock('@emotion/react', () => ({
+    jsx: (type, props) => ({type, props}),
+}));
+
+jest.mock('./components/icon.jsx', () => ({__esModule: true, default: () => null}));
+jest.mock('./components/post_type_webex', () => ({__esModule: true, default: () => null}));
+
+jest.mock('./actions', () => ({
+    startMeeting: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('./client', () => ({
+    __esModule: true,
+    default: {
+        setServerRoute: jest.fn(),
+    },
+}));
+
+jest.mock('mattermost-redux/selectors/entities/general', () => ({
+    getConfig: jest.fn(() => ({SiteURL: 'https://example.com'})),
+}));
+
+jest.mock('./selectors', () => ({
+    getServerRoute: jest.fn(() => ''),
+}));
+
+describe('Plugin initialization', () => {
+    let mockRegistry;
+    let mockStore;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        mockRegistry = {
+            registerChannelHeaderButtonAction: jest.fn(),
+            registerAppBarComponent: jest.fn(),
+            registerPostTypeComponent: jest.fn(),
+        };
+        mockStore = {
+            getState: jest.fn(() => ({})),
+            dispatch: jest.fn(),
+        };
+
+        // Mirror modern Mattermost: window.registerPlugin invokes initialize()
+        // synchronously during registration. If any module-scoped identifier
+        // used inside initialize() is still in the temporal dead zone at this
+        // point (e.g. a const arrow declared after registerPlugin), requiring
+        // ./index will throw a ReferenceError.
+        window.registerPlugin = jest.fn((_pluginId, plugin) => {
+            plugin.initialize(mockRegistry, mockStore);
+        });
+    });
+
+    test('module evaluation with synchronous initialize() does not throw', () => {
+        expect(() => {
+            jest.isolateModules(() => {
+                require('./index'); // eslint-disable-line global-require
+            });
+        }).not.toThrow();
+    });
+
+    test('registers channel header button, app bar icon, and post type component', () => {
+        jest.isolateModules(() => {
+            require('./index'); // eslint-disable-line global-require
+        });
+
+        expect(mockRegistry.registerChannelHeaderButtonAction).toHaveBeenCalledTimes(1);
+        expect(mockRegistry.registerAppBarComponent).toHaveBeenCalledTimes(1);
+        expect(mockRegistry.registerPostTypeComponent).toHaveBeenCalledWith(
+            'custom_webex',
+            expect.anything(),
+        );
+    });
+});

--- a/webapp/src/selectors.js
+++ b/webapp/src/selectors.js
@@ -1,0 +1,16 @@
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+
+export const getServerRoute = (state) => {
+    const config = getConfig(state);
+
+    let basePath = '';
+    if (config && config.SiteURL) {
+        basePath = new URL(config.SiteURL).pathname;
+
+        if (basePath && basePath[basePath.length - 1] === '/') {
+            basePath = basePath.substr(0, basePath.length - 1);
+        }
+    }
+
+    return basePath;
+};

--- a/webapp/src/selectors.js
+++ b/webapp/src/selectors.js
@@ -5,10 +5,14 @@ export const getServerRoute = (state) => {
 
     let basePath = '';
     if (config && config.SiteURL) {
-        basePath = new URL(config.SiteURL).pathname;
+        try {
+            basePath = new URL(config.SiteURL).pathname;
 
-        if (basePath && basePath[basePath.length - 1] === '/') {
-            basePath = basePath.substr(0, basePath.length - 1);
+            if (basePath && basePath[basePath.length - 1] === '/') {
+                basePath = basePath.substr(0, basePath.length - 1);
+            }
+        } catch (e) {
+            basePath = '';
         }
     }
 

--- a/webapp/src/selectors.test.js
+++ b/webapp/src/selectors.test.js
@@ -1,0 +1,48 @@
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+
+import {getServerRoute} from './selectors';
+
+jest.mock('mattermost-redux/selectors/entities/general', () => ({
+    getConfig: jest.fn(),
+}));
+
+describe('getServerRoute', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('returns empty string when config is missing', () => {
+        getConfig.mockReturnValue(null);
+        expect(getServerRoute({})).toBe('');
+    });
+
+    test('returns empty string when SiteURL is missing', () => {
+        getConfig.mockReturnValue({});
+        expect(getServerRoute({})).toBe('');
+    });
+
+    test('returns empty string when SiteURL has no subpath', () => {
+        getConfig.mockReturnValue({SiteURL: 'https://example.com'});
+        expect(getServerRoute({})).toBe('');
+    });
+
+    test('returns pathname when SiteURL has a subpath', () => {
+        getConfig.mockReturnValue({SiteURL: 'https://example.com/mattermost'});
+        expect(getServerRoute({})).toBe('/mattermost');
+    });
+
+    test('strips trailing slash from subpath', () => {
+        getConfig.mockReturnValue({SiteURL: 'https://example.com/mattermost/'});
+        expect(getServerRoute({})).toBe('/mattermost');
+    });
+
+    test('returns empty string when SiteURL is a bare root URL with trailing slash', () => {
+        getConfig.mockReturnValue({SiteURL: 'https://example.com/'});
+        expect(getServerRoute({})).toBe('');
+    });
+
+    test('returns empty string when SiteURL is malformed', () => {
+        getConfig.mockReturnValue({SiteURL: 'not a valid url'});
+        expect(getServerRoute({})).toBe('');
+    });
+});


### PR DESCRIPTION
#### Summary

Move `getServerRoute` from `index.js` into a new `selectors.js` module and import it, mirroring the structure of the GitHub, GitLab, and Jira plugins. Fixes a `ReferenceError: Cannot access 'getServerRoute' before initialization` thrown from `Plugin.initialize()` on Mattermost v11.x, which hangs the webapp on the loading spinner.

Also adds a regression test that mocks `window.registerPlugin` to synchronously invoke `initialize()` (mirroring modern Mattermost) and asserts the module loads without throwing. Temporarily reintroducing the original inline `const` declaration in `index.js` causes the test to fail with the same `ReferenceError` seen at runtime.

#### Ticket Link

Fixes https://github.com/mattermost-community/mattermost-plugin-webex/issues/83