### PR TITLE
fix: remove stale @emotion/react mock from webapp unit tests

### DIFF
--- a/webapp/src/index.test.js
+++ b/webapp/src/index.test.js
@@ -4,10 +4,6 @@
 
 /* eslint-disable max-nested-callbacks */
 
-jest.mock('@emotion/react', () => ({
-    jsx: (type, props) => ({type, props}),
-}));
-
 jest.mock('./components/icon.jsx', () => ({__esModule: true, default: () => null}));
 jest.mock('./components/post_type_webex', () => ({__esModule: true, default: () => null}));
 


### PR DESCRIPTION
Duplicates #87 so a reviewer with merge permission can land the fix ahead of the next release.

## Summary

After #84 (which added `webapp/src/index.test.js`) and #86 (which removed `@emotion/babel-preset-css-prop` and the unused `@emotion/react` dep) both merged, `npm test` on master fails: the new test file `jest.mock`s `@emotion/react`, which no longer exists in the dependency graph. Both PRs' CI passed individually — the incompatibility only surfaced once both were on master.

Fix: drop the now-unnecessary `jest.mock('@emotion/react', ...)` block from `webapp/src/index.test.js`. Nothing in the code under test imports `@emotion/react`, so no replacement mock is needed.

## Test plan

- [x] `npm test` in `webapp/` — all 3 suites / 10 tests pass locally
- [ ] CI (webapp lint + test + build) passes on this PR